### PR TITLE
Fix JitPack build

### DIFF
--- a/enchanting-bundler/build.gradle.kts
+++ b/enchanting-bundler/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.shadow)
+  `maven-publish`
 }
 
 dependencies {
@@ -32,4 +33,15 @@ tasks.assemble {
 
 artifacts {
   add("default", tasks.shadowJar)
+}
+
+publishing {
+  publications {
+    create<MavenPublication>("maven") {
+      from(components["shadow"])
+    }
+  }
+  repositories {
+    mavenLocal()
+  }
 }


### PR DESCRIPTION
Adds local maven publication for finalized jar.

Looks like JitPack no longer just grabs every jar in the folder structure, which is probably for the best.